### PR TITLE
Use normalized biomass and normalized NDVI. RE:#8

### DIFF
--- a/tests/test_forage.py
+++ b/tests/test_forage.py
@@ -1030,7 +1030,7 @@ class foragetests(unittest.TestCase):
             'bulk_density_path': os.path.join(
                 SAMPLE_DATA, 'soil', 'bulkd.tif'),
             'ph_path': os.path.join(
-                SAMPLE_DATA, 'soil', 'phihox_sl3.tif'),
+                SAMPLE_DATA, 'soil', 'pH.tif'),
             'clay_proportion_path': os.path.join(
                 SAMPLE_DATA, 'soil', 'clay.tif'),
             'silt_proportion_path': os.path.join(
@@ -10695,75 +10695,6 @@ class foragetests(unittest.TestCase):
         self.assert_all_values_in_raster_within_range(
             month_reg['diet_sufficiency'], diet_sufficiency - tolerance,
             diet_sufficiency + tolerance, _TARGET_NODATA)
-
-    def test_estimate_animal_density(self):
-        """Test `_estimate_animal_density`.
-
-        Use the function `_estimate_animal_density` to calculate animal density
-        in areas grazed by animals.  Ensure that estimated animal density
-        matches values calculated by hand.
-
-        Raises:
-            AssertionError if animal density values do not match values
-                calculated by hand
-
-        Returns:
-            None
-
-        """
-        from rangeland_production import forage
-        tolerance = 0.000001
-
-        # known inputs
-        aglivc = 0.6
-        stdedc = 0.6
-        EO_index = 2.
-
-        month_index = 1
-        pft_id_set = [1]
-        animal_mgmt_layer_path = TEST_AOI
-        aligned_inputs = {
-            'site_index': os.path.join(self.workspace_dir, 'site.tif'),
-            'pft_1': os.path.join(self.workspace_dir, 'pft_1.tif'),
-            'EO_index_1': os.path.join(self.workspace_dir, 'EO_index.tif'),
-            'animal_index': os.path.join(
-                self.workspace_dir, 'animal_index.tif'),
-        }
-        create_constant_raster(aligned_inputs['site_index'], 1)
-        create_constant_raster(aligned_inputs['pft_1'], 1)
-        create_constant_raster(aligned_inputs['EO_index_1'], EO_index)
-        pygeoprocessing.new_raster_from_base(
-            aligned_inputs['site_index'], aligned_inputs['animal_index'],
-            gdal.GDT_Int32, [_TARGET_NODATA], fill_value_list=[_TARGET_NODATA])
-        pygeoprocessing.rasterize(
-            animal_mgmt_layer_path, aligned_inputs['animal_index'],
-            option_list=["ATTRIBUTE=animal_id"])
-
-        site_param_table = {
-            1: {
-                'eo_biomass_intercept': 0,
-                'eo_biomass_slope': 1,
-            }
-        }
-        sv_reg = {
-            'aglivc_1_path': os.path.join(self.workspace_dir, 'aglivc_1.tif'),
-            'stdedc_1_path': os.path.join(self.workspace_dir, 'stdedc_1.tif'),
-        }
-        create_constant_raster(sv_reg['aglivc_1_path'], aglivc)
-        create_constant_raster(sv_reg['stdedc_1_path'], stdedc)
-        month_reg = {
-            'animal_density': os.path.join(
-                self.workspace_dir, 'animal_density.tif'),
-        }
-        obs_biomass_path = os.path.join(self.workspace_dir, 'obs_biomass.tif')
-
-        animals_per_ha = 0.00011449
-        forage._estimate_animal_density(
-            aligned_inputs, month_index, pft_id_set, site_param_table,
-            animal_mgmt_layer_path, sv_reg, obs_biomass_path, month_reg)
-        self.assert_all_values_in_raster_within_range(
-            month_reg['animal_density'], animals_per_ha - tolerance,
-            animals_per_ha + tolerance, _TARGET_NODATA)
 
     def test_initial_conditions_from_tables(self):
         """Test `initial_conditions_from_tables`.


### PR DESCRIPTION
This PR addresses issue #8, adding a new feature to disaggregate animals through comparison to normalized NDVI or another remotely sensed vegetation index that is interpreted as an indicator of empirical vegetation biomass.  This replaces the previous method of disaggregating animals via the absolute value mismatch between potential biomass (from RPM) and empirical biomass (calculated from NDVI via linear regression).

This entailed only a few changes:
- replace the function `_estimate_animal_density()`
- remove the inputs in the site parameter table that were used to calculate absolute biomass from NDVI, EO_biomass_intercept and EO_biomass_slope

I tested this change by running RPM with realistic inputs and checking the results in a few ways:
- Run the model with raw NDVI inputs, and with the same NDVI inputs scaled by 0.8.  Ensure that animal distribution and standing biomass outputs are close to identical
- Calculate zonal statistics from animal density outputs over a range of months, using the soums as zones. Ensure that total animals per soum is identical between months.
- Check the maximum density of animals per pixel and compare to the maximum value when using the previous method of disaggregating via absolute value. Ensure that the maximum density is lower (i.e., animals are not "piling up on pixels").