### PR TITLE
add handling for special case when min val == max val

### DIFF
--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -13342,9 +13342,17 @@ def normalize_within_grazing_areas(
             (max_value != _TARGET_NODATA))
         normalized = numpy.empty(value.shape, dtype=numpy.float32)
         normalized[:] = _TARGET_NODATA
-        normalized[valid_mask] = (
-            (value[valid_mask] - min_value[valid_mask]) /
-            (max_value[valid_mask] - min_value[valid_mask]))
+        # special case: all pixels have equal value inside grazing feature
+        zero_mask = (
+            (numpy.isclose(min_value, max_value)) &
+            valid_mask)
+        normalized[zero_mask] = 0.5
+        nonzero_mask = (
+            (~numpy.isclose(min_value, max_value)) &
+            valid_mask)
+        normalized[nonzero_mask] = (
+            (value[nonzero_mask] - min_value[nonzero_mask]) /
+            (max_value[nonzero_mask] - min_value[nonzero_mask]))
         return normalized
 
     temp_dir = tempfile.mkdtemp(dir=PROCESSING_DIR)


### PR DESCRIPTION
This PR includes one small bugfix for the new animal spatial distribution submodel, using normalized NDVI and biomass values to compute animal densities.  To handle the special case when all pixels inside a grazing feature have equal value (e.g., during the first step when the model is initialized from values in tables), set normalized potential biomass to 0.5 if the min value and max value of simulated value within a grazing feature are equal.

Closes #10 