### PR TITLE
Feature/summary results

### DIFF
--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -643,7 +643,7 @@ def execute(args):
     try:
         delete_sv_folders = not args['save_sv_rasters']
     except KeyError:
-        delete_sv_folders = False
+        delete_sv_folders = True
 
     # this set will build up the integer months that are used so we can index
     # the mwith temperature later

--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -627,6 +627,9 @@ def execute(args):
             plant functional type index and each state variable listed in the
             following table:
             https://docs.google.com/spreadsheets/d/1TGCDOJS4nNsJpzTWdiWed390NmbhQFB2uUoMs9oTTYo/edit?usp=sharing
+        args['save_sv_rasters'] (boolean): optional input, default true. Should
+            rasters containing all state variables be saved for each model time
+            step?
 
     Returns:
         None.
@@ -636,6 +639,11 @@ def execute(args):
     starting_month = int(args['starting_month'])
     starting_year = int(args['starting_year'])
     n_months = int(args['n_months'])
+    try:
+        delete_sv_folders = not args['save_sv_rasters']
+    except KeyError:
+        delete_sv_folders = False
+
     # this set will build up the integer months that are used so we can index
     # the mwith temperature later
     temperature_month_set = set()
@@ -1173,7 +1181,12 @@ def execute(args):
     # clean up
     shutil.rmtree(persist_param_dir)
     shutil.rmtree(PROCESSING_DIR)
-
+    if delete_sv_folders:
+        for month_index in range(-1, n_months):
+            shutil.rmtree(
+                os.path.join(
+                    args['workspace_dir'],
+                    'state_variables_m%d' % month_index))
 
 def raster_multiplication(
         raster1, raster1_nodata, raster2, raster2_nodata, target_path,

--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -628,9 +628,9 @@ def execute(args):
             plant functional type index and each state variable listed in the
             following table:
             https://docs.google.com/spreadsheets/d/1TGCDOJS4nNsJpzTWdiWed390NmbhQFB2uUoMs9oTTYo/edit?usp=sharing
-        args['save_sv_rasters'] (boolean): optional input, default true. Should
-            rasters containing all state variables be saved for each model time
-            step?
+        args['save_sv_rasters'] (boolean): optional input, default false.
+            Should rasters containing all state variables be saved for each
+            model time step?
 
     Returns:
         None.
@@ -13942,8 +13942,9 @@ def calc_mean_animal_density(output_dir, target_path):
     """Calculate mean animal density inside each pixel during the model run.
 
     Calculate mean animal density per pixel across months of the simulation.
-    Calculate the mean for all pixels that have >1 valid value during the
-    months of the simulation, discarding months without valid values.
+    Calculate the mean for all pixels that have >0 valid value during the
+    months of the simulation, discarding months without valid values in the
+    calculation of the average.
 
     Parameters:
         output_dir (string): path to directory containing output rasters

--- a/src/rangeland_production/ui/forage.py
+++ b/src/rangeland_production/ui/forage.py
@@ -315,7 +315,7 @@ class Forage(model.InVESTModel):
             args_key=u'save_sv_rasters',
             helptext=(u"Should rasters for each state variable, for each "
                 "timestep, be saved?"),
-            label=u'Save State Variable Rasters', validator=self.validator)
+            label=u'Save State Variable Rasters')
         self.add_input(self.save_sv_rasters)
 
     def assemble_args(self):
@@ -358,7 +358,7 @@ class Forage(model.InVESTModel):
                 self.initial_conditions_dir.value(),
             self.site_initial_table.args_key: self.site_initial_table.value(),
             self.pft_initial_table.args_key: self.pft_initial_table.value(),
-            self.save_sv_rasters.args_key: self.save_sv_rasters.values(),
+            self.save_sv_rasters.args_key: self.save_sv_rasters.value(),
         }
 
         return args

--- a/src/rangeland_production/ui/forage.py
+++ b/src/rangeland_production/ui/forage.py
@@ -311,6 +311,12 @@ class Forage(model.InVESTModel):
             label=u'Initial Conditions Table: PFT State Variables',
             validator=self.validator)
         self.add_input(self.pft_initial_table)
+        self.save_sv_rasters = inputs.Checkbox(
+            args_key=u'save_sv_rasters',
+            helptext=(u"Should rasters for each state variable, for each "
+                "timestep, be saved?"),
+            label=u'Save State Variable Rasters', validator=self.validator)
+        self.add_input(self.save_sv_rasters)
 
     def assemble_args(self):
         args = {
@@ -352,6 +358,7 @@ class Forage(model.InVESTModel):
                 self.initial_conditions_dir.value(),
             self.site_initial_table.args_key: self.site_initial_table.value(),
             self.pft_initial_table.args_key: self.pft_initial_table.value(),
+            self.save_sv_rasters.args_key: self.save_sv_rasters.values(),
         }
 
         return args


### PR DESCRIPTION
Calculate summary results that aggregate biomass, animal density, and animal diet sufficiency across time steps and/or pixels.  Calculate mean potential biomass, standing biomass, and animal diet sufficiency across time steps and across pixels within grazing area polygons.  Append these values as fields to a summary results shapefile, "//workspace/outputs/summary_results/grazing_areas_results_rpm.shp".  Calculate mean animal density per pixel across time steps sand save this as "//workspace/outputs/summary_results/mean_animal_density.tif".

Add the option to save all state variable rasters as output, but change the default behavior of the model to delete all state variable rasters from disk when the model finishes successfully.