### PR TITLE
Bugfix/build 6 missing projdb

### DIFF
--- a/exe/hooks/hook-osgeo.py
+++ b/exe/hooks/hook-osgeo.py
@@ -1,12 +1,16 @@
 from PyInstaller.compat import is_darwin
+from PyInstaller.utils.hooks import (collect_system_data_files,
+                                     collect_data_files,
+                                     collect_submodules)
 import os
 
 if is_darwin:
-    # Assume we're using homebrew to install GDAL and collect data files
-    # accordingly.
-    from PyInstaller.utils.hooks import get_homebrew_path
-    from PyInstaller.utils.hooks import collect_system_data_files
-
-    datas = collect_system_data_files(
-        path=os.path.join(get_homebrew_path('gdal'), 'share', 'gdal'),
-        destdir='gdal-data')
+    # Assume we're using a local conda env to install gdal.
+    # glob for gcs.csv instead of passing the env name.
+    # import glob
+    # datas = collect_system_data_files(
+    #   path=os.path.dirname(glob.glob('**/gcs.csv', recursive=True)[0]),
+    #     destdir='gdal-data')
+    pass
+else:
+    datas = collect_data_files('osgeo')

--- a/src/rangeland_production/utils.py
+++ b/src/rangeland_production/utils.py
@@ -103,8 +103,7 @@ def prepare_workspace(workspace, name, logging_level=logging.NOTSET,
 
     logfile = os.path.join(
         workspace,
-        'InVEST-{modelname}-log-{timestamp}.txt'.format(
-            modelname='-'.join(name.replace(':', '').split(' ')),
+        'Rangeland-Production-Model-log-{timestamp}.txt'.format(
             timestamp=datetime.now().strftime("%Y-%m-%d--%H_%M_%S")))
 
     with capture_gdal_logging(), log_to_file(logfile,


### PR DESCRIPTION
This PR fixes #6, where rasters created by RPM's standalone executable had undefined coordinate reference system.  It also removes the name "InVEST" from the logfile created by the model when run from the user interface.