### PR TITLE
Feature/crude protein 29 protein input

### DIFF
--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -634,6 +634,12 @@ def execute(args):
         args['save_sv_rasters'] (boolean): optional input, default false.
             Should rasters containing all state variables be saved for each
             model time step?
+        args['crude_protein'] (float): optional input, crude protein
+            concentration of forage for the purposes of animal diet selection.
+            Should be a value between 0-1. If included, this value is
+            substituted for N content of forage when calculating digestibility
+            and "ingestibility" of forage, and protein content of the diet, for
+            grazing animals.
 
     Returns:
         None.


### PR DESCRIPTION
Added a new optional input to the args dictionary, 'crude_protein'.  This should be a value between 0-1 that describes crude protein content of forage for the purposes of animal intake and diet sufficiency. It may be drawn from the literature.  When this value is included, it is applied to all forage types. It supersedes the calculation of protein content from the N and C content of biomass in forage calculated by Century in the following places:
 1) in calculation of digestibility of forage, which influences "ingestibility" and therefore predicted intake of forage
 2) in calculation of protein content of the diet selected, which influences restriction of maximum potential intake

Fixes #29, closes #29 .
