### PR TITLE
fix calculation of protein intake when L > 0

### DIFF
--- a/src/rangeland_production/forage.py
+++ b/src/rangeland_production/forage.py
@@ -12237,9 +12237,9 @@ def revise_max_intake(
         valid_mask)
     corrected_protein_intake[high_intake_mask] = (
         degr_protein_intake[high_intake_mask] * (
-            1. - CRD1[high_intake_mask] - CRD2[high_intake_mask] *
+            1. - (CRD1[high_intake_mask] - CRD2[high_intake_mask] *
             total_digestibility[high_intake_mask]) *
-        feeding_level[high_intake_mask])
+        feeding_level[high_intake_mask]))
 
     reduction_factor = numpy.empty(max_intake.shape, dtype=numpy.float32)
     reduction_factor[valid_mask] = 1.


### PR DESCRIPTION
This small fix corrects a very big error when intake of forage is high: correction of degradable protein intake according to feeding level (the ratio of metabolizable energy intake to maintenance energy requirements) should reduce protein intake by a tiny amount, rather than reducing it TO a tiny amount.

This PR fixes #38 